### PR TITLE
Update RMagick

### DIFF
--- a/lib/zxing/version.rb
+++ b/lib/zxing/version.rb
@@ -1,5 +1,5 @@
 module ZXing
-  VERSION = "0.1.1" unless defined?(::ZXing::VERSION)
+  VERSION = "0.1.2" unless defined?(::ZXing::VERSION)
 
   VERSION_INFO = {}
   VERSION_INFO['warnings']              = []

--- a/zxing_cpp.gemspec
+++ b/zxing_cpp.gemspec
@@ -38,11 +38,11 @@ Gem::Specification.new do |s|
   s.test_files = s.files.grep(%r{^test/})
   s.require_paths = ['lib', 'ext']
 
-  s.add_development_dependency 'bundler', '~> 1.6'
-  s.add_development_dependency 'rake', '~> 10.4'
-  s.add_development_dependency 'rake-compiler', '~> 0.9'
+  s.add_development_dependency 'bundler'
+  s.add_development_dependency 'rake'
+  s.add_development_dependency 'rake-compiler'
   s.add_development_dependency 'shoulda', '~> 3.5'
 
-  s.add_dependency 'ffi', '~> 1.1'
-  s.add_dependency 'rmagick', '~> 2.13'
+  s.add_dependency 'ffi'
+  s.add_dependency 'rmagick'
 end


### PR DESCRIPTION
Doesn't work on Mac M2:

```
current directory: /Users/christian/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/bundler/gems/zxing_cpp.rb-e22b3a0b7ce2/ext/zxing
make DESTDIR\= sitearchdir\=./.gem.20240117-42481-cd91xj sitelibdir\=./.gem.20240117-42481-cd91xj clean

current directory: /Users/christian/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/bundler/gems/zxing_cpp.rb-e22b3a0b7ce2/ext/zxing
make DESTDIR\= sitearchdir\=./.gem.20240117-42481-cd91xj sitelibdir\=./.gem.20240117-42481-cd91xj
compiling zxing.cc
linking shared-object zxing/zxing.bundle
ld: warning: ignoring duplicate libraries: '-lc++', '-lruby.3.2'
ld: Undefined symbols:
  _iconv, referenced from:
      (anonymous namespace)::add(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, char) in libzxing.a[24](Decoder.cpp.o)
zxing::qrcode::DecodedBitStreamParser::append(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, char const*, unsigned
long, char const*) in libzxing.a[93](DecodedBitStreamParser.cpp.o)
  _iconv_close, referenced from:
      (anonymous namespace)::add(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, char) in libzxing.a[24](Decoder.cpp.o)
zxing::qrcode::DecodedBitStreamParser::append(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, char const*, unsigned
long, char const*) in libzxing.a[93](DecodedBitStreamParser.cpp.o)
zxing::qrcode::DecodedBitStreamParser::append(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, char const*, unsigned
long, char const*) in libzxing.a[93](DecodedBitStreamParser.cpp.o)
  _iconv_open, referenced from:
      (anonymous namespace)::add(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, char) in libzxing.a[24](Decoder.cpp.o)
zxing::qrcode::DecodedBitStreamParser::append(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, char const*, unsigned
long, char const*) in libzxing.a[93](DecodedBitStreamParser.cpp.o)
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [zxing.bundle] Error 1

make failed, exit code 2
```